### PR TITLE
Extend the json seriaization

### DIFF
--- a/tinyrpc/protocols/jsonrpc.py
+++ b/tinyrpc/protocols/jsonrpc.py
@@ -53,6 +53,13 @@ class JSONRPCServerError(FixedErrorMessageMixin, InvalidRequestError):
     message = ''
 
 
+def for_json_bridge(o):
+    try:
+        return o.for_json()
+    except AttributeError, e:
+        print e
+        raise TypeError('{0} is not JSON serializable'.format(o))
+    
 class JSONRPCSuccessResponse(RPCResponse):
     def _to_dict(self):
         return {
@@ -62,7 +69,7 @@ class JSONRPCSuccessResponse(RPCResponse):
         }
 
     def serialize(self):
-        return json.dumps(self._to_dict())
+        return json.dumps(self._to_dict(), default=for_json_bridge)
 
 
 class JSONRPCErrorResponse(RPCErrorResponse):
@@ -142,7 +149,7 @@ class JSONRPCRequest(RPCRequest):
         return jdata
 
     def serialize(self):
-        return json.dumps(self._to_dict())
+        return json.dumps(self._to_dict(), default=for_json_bridge)
 
 
 class JSONRPCBatchRequest(RPCBatchRequest):

--- a/tinyrpc/protocols/jsonrpc.py
+++ b/tinyrpc/protocols/jsonrpc.py
@@ -57,7 +57,6 @@ def for_json_bridge(o):
     try:
         return o.for_json()
     except AttributeError, e:
-        print e
         raise TypeError('{0} is not JSON serializable'.format(o))
     
 class JSONRPCSuccessResponse(RPCResponse):


### PR DESCRIPTION
Objects that are not json-serializable are asked to use a 'for_json' method that returns something json-serializable.
