### PR TITLE
Allow to set post_method in HttpPostClientTransport

### DIFF
--- a/tinyrpc/transports/http.py
+++ b/tinyrpc/transports/http.py
@@ -16,21 +16,26 @@ class HttpPostClientTransport(ClientTransport):
     an ``HTTP`` ``POST`` request. Replies are taken from the responses body.
 
     :param endpoint: The URL to send ``POST`` data to.
+    :param post_method: allows to replace `requests.post` with another method,
+        e.g. the post method of a `requests.Session()` instance.
     :param kwargs: Additional parameters for :py:func:`requests.post`.
     """
-    def __init__(self, endpoint, **kwargs):
+    def __init__(self, endpoint, post_method=None, **kwargs):
         self.endpoint = endpoint
         self.request_kwargs = kwargs
+        if post_method is None:
+            self.post = requests.post
+        else:
+            self.post = post_method
 
     def send_message(self, message, expect_reply=True):
         if not isinstance(message, str):
             raise TypeError('str expected')
 
-        r = requests.post(self.endpoint, data=message, **self.request_kwargs)
+        r = self.post(self.endpoint, data=message, **self.request_kwargs)
 
         if expect_reply:
             return r.content
-
 
 
 class HttpWebSocketClientTransport(ClientTransport):

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps=
     pytest
     werkzeug
     py27: gevent
+    py27: gevent-websocket
     py33,py34: gevent>=1.1b5
     requests
     zmq


### PR DESCRIPTION
Fixes #26.
In some applications it is desirable to limit the number of ports used by a client (see issue #26). This change allows to supply an alternative method to the default `requests.post` being used in `send_message`.

The change is introduced backwards compatible with the introduction of a new kwarg to the constructor, `post_method=None`.

Users can create a `requests.Session()` instance, (optionally mount a `requests.adapters.HTTPAdapter` to control the pool size), and supply `post_method=session.post` as the kwarg.
    
- `test_wsgi_transport.py::sessioned_client` shows an application of the kwarg.
- `test_wsgi_transport.py::test_exhaust_ports` displays the problem with a non sesioned `HttpPostClientTransport` instance.


@mbr Please also consider to create a 0.5.1 release with this change backported. The 0.5 version is desirable in applications that want to avoid depending on `six`. I have the patch ready in my fork: https://github.com/konradkonrad/tinyrpc/tree/use_session_backport