### PR TITLE
Modified to support python 3.x

### DIFF
--- a/examples/http_client_example.py
+++ b/examples/http_client_example.py
@@ -15,4 +15,4 @@ remote_server = rpc_client.get_proxy()
 # call a method called 'reverse_string' with a single string argument
 result = remote_server.reverse_string('Hello, World!')
 
-print "Server answered:", result
+print("Server answered:", result)

--- a/examples/zmq_client_example.py
+++ b/examples/zmq_client_example.py
@@ -19,4 +19,4 @@ remote_server = rpc_client.get_proxy()
 # call a method called 'reverse_string' with a single string argument
 result = remote_server.reverse_string('Hello, World!')
 
-print "Server answered:", result
+print("Server answered:", result)

--- a/tinyrpc/transports/http.py
+++ b/tinyrpc/transports/http.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from Queue import Queue
 import threading
 import requests
 import websocket
 
+from six.moves import queue as Queue
 from . import ServerTransport, ClientTransport
 
 

--- a/tinyrpc/transports/websocket.py
+++ b/tinyrpc/transports/websocket.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import Queue
+from six.moves import queue as Queue
 
 from . import ServerTransport
 from geventwebsocket.resource import WebSocketApplication, Resource


### PR DESCRIPTION
When I tried to import `tinyrpc`, I got this error.

```
File "/usr/local/lib/python3.5/dist-packages/tinyrpc/transports/http.py", line 4, in <module>
    from Queue import Queue
ImportError: No module named 'Queue'
```

so, I modified code to avoid version problems.

```python
from six.moves import queue as Queue
```

this is related with issue #12 