### PR TITLE
Fix TypeError message in 'send_message'

### DIFF
--- a/tinyrpc/transports/http.py
+++ b/tinyrpc/transports/http.py
@@ -29,7 +29,7 @@ class HttpPostClientTransport(ClientTransport):
 
     def send_message(self, message, expect_reply=True):
         if not isinstance(message, six.binary_type):
-            raise TypeError('str expected')
+            raise TypeError('bytes expected')
 
         r = self.post(self.endpoint, data=message, **self.request_kwargs)
 


### PR DESCRIPTION
This gave me some headache as I was sure the parameter was a string, but actually `bytes` are required.