### PR TITLE
Implamentation fixes

### DIFF
--- a/tests/test_jsonrpc.py
+++ b/tests/test_jsonrpc.py
@@ -458,13 +458,16 @@ def test_jsonrpc_spec_v2_example11(prot):
 
 
 def test_jsonrpc_spec_v2_example12(prot):
-    reqs = []
-    reqs.append(prot.create_request('notify_sum', [1, 2, 4], one_way=True))
-    reqs.append(prot.create_request('notify_hello', [7], one_way=True))
+    reqs = [
+        prot.create_request('notify_sum', [1, 2, 4], one_way=True),
+        prot.create_request('notify_hello', [7], one_way=True),
+    ]
 
     request = prot.create_batch_request(reqs)
+    response = request.create_batch_response()
 
-    assert request.create_batch_response() == None
+    assert len(response) == 0
+    assert response.serialize() == ''
 
 
 def test_can_get_custom_error_messages_out(prot):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -4,7 +4,6 @@
 import pytest
 
 from tinyrpc.protocols.jsonrpc import JSONRPCProtocol
-from tinyrpc import RPCErrorResponse
 
 
 @pytest.fixture(params=['jsonrpc'])
@@ -20,6 +19,7 @@ def test_protocol_returns_strings(protocol):
 
     assert isinstance(req.serialize(), str)
 
+
 def test_procotol_responds_strings(protocol):
     req = protocol.create_request('foo', ['bar'])
     rep = req.respond(42)
@@ -32,7 +32,7 @@ def test_procotol_responds_strings(protocol):
 def test_one_way(protocol):
     req = protocol.create_request('foo', None, {'a': 'b'}, True)
 
-    assert req.respond(None) == None
+    assert req.respond(None) is None
 
 
 def test_raises_on_args_and_kwargs(protocol):

--- a/tinyrpc/dispatch/__init__.py
+++ b/tinyrpc/dispatch/__init__.py
@@ -101,7 +101,7 @@ class RPCDispatcher(object):
             results = [self._dispatch(req, caller) for req in request]
 
             response = request.create_batch_response()
-            if response != None:
+            if response is not None:
                 response.extend(results)
 
             return response

--- a/tinyrpc/protocols/__init__.py
+++ b/tinyrpc/protocols/__init__.py
@@ -1,28 +1,25 @@
-#!/usr/bin/env python
-
-from ..exc import *
-
 class RPCRequest(object):
-    unique_id = None
-    """A unique ID to remember the request by. Protocol specific, may or
-    may not be set. This value should only be set by
-    :py:func:`~tinyrpc.RPCProtocol.create_request`.
+    def __init__(self):
+        self.unique_id = None
+        """A unique ID to remember the request by. Protocol specific, may or
+        may not be set. This value should only be set by
+        :py:func:`~tinyrpc.RPCProtocol.create_request`.
 
-    The ID allows client to receive responses out-of-order and still allocate
-    them to the correct request.
+        The ID allows client to receive responses out-of-order and still allocate
+        them to the correct request.
 
-    Only supported if the parent protocol has
-    :py:attr:`~tinyrpc.RPCProtocol.supports_out_of_order` set to ``True``.
-    """
+        Only supported if the parent protocol has
+        :py:attr:`~tinyrpc.RPCProtocol.supports_out_of_order` set to ``True``.
+        """
 
-    method = None
-    """The name of the method to be called."""
+        self.method = None
+        """The name of the method to be called."""
 
-    args = []
-    """The positional arguments of the method call."""
+        self.args = []
+        """The positional arguments of the method call."""
 
-    kwargs = {}
-    """The keyword arguments of the method call."""
+        self.kwargs = {}
+        """The keyword arguments of the method call."""
 
     def error_respond(self, error):
         """Creates an error response.
@@ -94,7 +91,8 @@ class RPCResponse(object):
     an error occured, in which case an attribute ``error`` will contain the
     error message."""
 
-    unique_id = None
+    def __init__(self):
+        self.unique_id = None
 
     def serialize(self):
         """Returns a serialization of the response.

--- a/tinyrpc/protocols/jsonrpc.py
+++ b/tinyrpc/protocols/jsonrpc.py
@@ -306,7 +306,7 @@ class JSONRPCProtocol(RPCBatchProtocol):
         request.unique_id = req.get('id', None)
 
         params = req.get('params', None)
-        if params != None:
+        if params is not None:
             if isinstance(params, list):
                 request.args = req['params']
             elif isinstance(params, dict):

--- a/tinyrpc/protocols/jsonrpc.py
+++ b/tinyrpc/protocols/jsonrpc.py
@@ -77,7 +77,7 @@ class JSONRPCSuccessResponse(RPCResponse):
         }
 
     def serialize(self):
-        return json_dumps(self._to_dict())
+        return json_dumps(self._to_dict()) if self.unique_id is not None else ''
 
 
 class JSONRPCErrorResponse(RPCErrorResponse):
@@ -181,7 +181,8 @@ class JSONRPCBatchRequest(RPCBatchRequest):
 
 class JSONRPCBatchResponse(RPCBatchResponse):
     def serialize(self):
-        return json_dumps([resp._to_dict() for resp in self if resp != None])
+        results = [resp._to_dict() for resp in self if resp is not None]
+        return json_dumps(results) if len(results) > 0 else ''
 
 
 class JSONRPCProtocol(RPCBatchProtocol):

--- a/tinyrpc/protocols/jsonrpc.py
+++ b/tinyrpc/protocols/jsonrpc.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .. import RPCBatchProtocol, RPCRequest, RPCResponse, RPCErrorResponse,\
-               InvalidRequestError, MethodNotFoundError, ServerError,\
-               InvalidReplyError, RPCError, RPCBatchRequest, RPCBatchResponse
+from .. import (RPCBatchProtocol, RPCRequest, RPCResponse, RPCErrorResponse,
+                InvalidRequestError, MethodNotFoundError, InvalidReplyError,
+                RPCError, RPCBatchRequest, RPCBatchResponse)
 
 import json
 import six
@@ -17,6 +17,7 @@ if 'jsonext' in sys.modules:
     json_dumps = jsonext.dumps
 else:
     json_dumps = json.dumps
+
 
 class FixedErrorMessageMixin(object):
     def __init__(self, *args, **kwargs):
@@ -35,7 +36,6 @@ class FixedErrorMessageMixin(object):
         if hasattr(self, 'data'):
             response.data = self.data
         return response
-
 
 
 class JSONRPCParseError(FixedErrorMessageMixin, InvalidRequestError):
@@ -132,9 +132,6 @@ def _get_code_message_and_data(error):
 
 class JSONRPCRequest(RPCRequest):
     def error_respond(self, error):
-        if self.unique_id is None:
-            return None
-
         response = JSONRPCErrorResponse()
 
         code, msg, data = _get_code_message_and_data(error)
@@ -176,17 +173,7 @@ class JSONRPCRequest(RPCRequest):
 
 class JSONRPCBatchRequest(RPCBatchRequest):
     def create_batch_response(self):
-        if self._expects_response():
-            return JSONRPCBatchResponse()
-
-    def _expects_response(self):
-        for request in self:
-            if isinstance(request, Exception):
-                return True
-            if request.unique_id != None:
-                return True
-
-        return False
+        return JSONRPCBatchResponse()
 
     def serialize(self):
         return json_dumps([req._to_dict() for req in self])
@@ -259,8 +246,7 @@ class JSONRPCProtocol(RPCBatchProtocol):
 
         if ('error' in rep) == ('result' in rep):
             raise InvalidReplyError(
-                'Reply must contain exactly one of result and error.'
-            )
+                'Reply must contain exactly one of result and error.')
 
         if 'error' in rep:
             response = JSONRPCErrorResponse()


### PR DESCRIPTION
This PR includes fixes for a few issue that I have run into while using the lib.

* Fixed scoping issue for `RPCRequest` and `RPCResponse`, variables were class vars instead of instance vars. This was causing a race condition and instance pollution.
* Changed `JSONRPCRequest.error_respond` to always return a response even if no `unique_id` was provided as this is allowed under the specification.
* Changed `JSONRPCBatchRequest.create_batch_response` to always return a `JSONRPCBatchResponse` to facilitate returning error responses.
* Changed JSON-RPC `serialize` to return an empty string when the response would be `None`
* Updated `test_jsonrpc_spec_v2_example12` to work with the new batch response.