### PR TITLE
Fixed arguments not being passed to custom caller correctly

### DIFF
--- a/tinyrpc/dispatch/__init__.py
+++ b/tinyrpc/dispatch/__init__.py
@@ -121,7 +121,7 @@ class RPCDispatcher(object):
         # we found the method
         try:
             if caller is not None:
-                result = caller(method, request.args, request.kwargs)
+                result = caller(method, *request.args, **request.kwargs)
             else:
                 result = method(*request.args, **request.kwargs)
         except Exception as e:


### PR DESCRIPTION
The arguments are not passed correctly from dispatch() to the custom caller. For example, if we have a method with 0 arguments, the caller will nevertheless try to pass args and kwargs, resulting in a runtime error of 2 arguments passed when expecting 0. In my tests this fixes it, can someone confirm?