### PR TITLE
Update minimum `requests` version for security reasons.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyparsing==2.2.0
 pytest==3.6.3
 pytest-cov==2.5.1
 pyzmq==17.1.0
-requests==2.4.3
+requests>=2.20.0
 six==1.11.0
 tox==3.1.2
 virtualenv==16.0.0


### PR DESCRIPTION
`requests>=2.20.0` is required as 2.19 and below seem to have a known security issue.