### PR TITLE
WIP: support jsonrpc errors with data with JSONRPCProtocol.parse_reply

### DIFF
--- a/tests/test_jsonrpc.py
+++ b/tests/test_jsonrpc.py
@@ -12,7 +12,8 @@ from tinyrpc.protocols.jsonrpc import JSONRPCParseError, \
                                       JSONRPCInvalidRequestError, \
                                       JSONRPCMethodNotFoundError, \
                                       JSONRPCInvalidParamsError, \
-                                      JSONRPCInternalError
+                                      JSONRPCInternalError,\
+                                      JSONRPCErrorResponse
 
 
 def _json_equal(a, b):
@@ -515,11 +516,23 @@ def test_pass_error_data_with_standard_exception(prot):
     jmsg = jmsg.decode()
 
     decoded = json.loads(jmsg)
+    print("decoded=", decoded)
     assert decoded['error']['code'] == -32000
     assert decoded['error']['message'] == custom_msg
     assert decoded['error']['data'] == data
 
+    # on the client side, when reply is parsed
+    parsed_reply = prot.parse_reply(jmsg)
+    serialized_reply = parsed_reply.serialize().decode("utf-8")
+    decoded_reply = json.loads(serialized_reply)
+    print("decoded_reply=", decoded_reply)
+    assert isinstance(parsed_reply, JSONRPCErrorResponse)
+    assert hasattr(parsed_reply, "data")
+    assert serialized_reply == jmsg
+    assert decoded_reply == decoded
+
 def test_pass_error_data_with_custom_exception(prot):
+    # type: (JSONRPCProtocol) -> None
     request = prot.create_request('foo')
 
     data = {'pi': 3.14, 'lst': ['a', 'b', 'c']}
@@ -532,6 +545,18 @@ def test_pass_error_data_with_custom_exception(prot):
     jmsg = jmsg.decode()
 
     decoded = json.loads(jmsg)
+    print("decoded=", decoded)
     assert decoded['error']['code'] == -32700
     assert decoded['error']['message'] == JSONRPCParseError.message
     assert decoded['error']['data'] == data
+
+    # on the client side, when reply is parsed
+    parsed_reply = prot.parse_reply(jmsg)
+    serialized_reply = parsed_reply.serialize().decode("utf-8")
+    decoded_reply = json.loads(serialized_reply)
+    print("decoded_reply=", decoded_reply)
+    assert isinstance(parsed_reply, JSONRPCErrorResponse)
+    assert hasattr(parsed_reply, "data")
+    assert serialized_reply == jmsg
+    assert decoded_reply == decoded
+

--- a/tinyrpc/protocols/jsonrpc.py
+++ b/tinyrpc/protocols/jsonrpc.py
@@ -544,23 +544,27 @@ class JSONRPCProtocol(RPCBatchProtocol):
             if not k in self._ALLOWED_REPLY_KEYS:
                 raise InvalidReplyError('Key not allowed: %s' % k)
 
-        if not 'jsonrpc' in rep:
+        if 'jsonrpc' not in rep:
             raise InvalidReplyError('Missing jsonrpc (version) in response.')
 
         if rep['jsonrpc'] != self.JSON_RPC_VERSION:
             raise InvalidReplyError('Wrong JSONRPC version')
 
-        if not 'id' in rep:
+        if 'id' not in rep:
             raise InvalidReplyError('Missing id in response')
 
-        if ('error' in rep) == ('result' in rep):
+        if ('error' in rep) and ('result' in rep):
             raise InvalidReplyError(
                 'Reply must contain exactly one of result and error.'
             )
 
         if 'error' in rep:
             response = JSONRPCErrorResponse()
-            response.error = rep['error']
+            error = rep['error']
+            response.error = error["message"]
+            response._jsonrpc_error_code = error["code"]
+            if "data" in error:
+                response.data = error["data"]
         else:
             response = JSONRPCSuccessResponse()
             response.result = rep.get('result', None)


### PR DESCRIPTION
This is to follow up on #20 .

Started by adding failing test assertions that demonstrate the problem. Also revealed another error when calling `serialize` on an error obtained using `parse_reply`:
```
    def _to_dict(self):
        msg = {
            'jsonrpc': JSONRPCProtocol.JSON_RPC_VERSION,
            'id': self.unique_id,
            'error': {
                'message': str(self.error),
>               'code': self._jsonrpc_error_code
            }
        }
E       AttributeError: 'JSONRPCErrorResponse' object has no attribute '_jsonrpc_error_code'

```