### PR TITLE
Passing one-way specification to transport. Fixes #78.

### DIFF
--- a/tinyrpc/client.py
+++ b/tinyrpc/client.py
@@ -49,7 +49,7 @@ class RPCClient(object):
         tport = self.transport if transport is None else transport
 
         # sends ...
-        reply = tport.send_message(req.serialize())
+        reply = tport.send_message(req.serialize(), expect_reply=(not one_way))
 
         if one_way:
             # ... and be done

--- a/tinyrpc/transports/zmq.py
+++ b/tinyrpc/transports/zmq.py
@@ -58,8 +58,12 @@ class ZmqClientTransport(ClientTransport):
     def send_message(self, message: bytes, expect_reply: bool = True) -> bytes:
         self.socket.send(message)
 
+        # zmq contains a state machine preventing a new request
+        # until the previous one is answered, so always receive
+        reply = self.socket.recv()
+
         if expect_reply:
-            return self.socket.recv()
+            return reply
 
     @classmethod
     def create(cls, zmq_context: zmq.Context, endpoint: str) -> 'ZmqClientTransport':


### PR DESCRIPTION
Passing one-way specification to transport. Fixes #78.
- updated client's `_send_and_handle_reply` to specify if transport
  should expect reply when sending message
- updated zmq transport to always wait for reply after sending message