### PR TITLE
Improve typing of @public decorators

### DIFF
--- a/tinyrpc/dispatch/__init__.py
+++ b/tinyrpc/dispatch/__init__.py
@@ -27,7 +27,7 @@ def public(name: Callable[..., T]) -> Callable[..., T]:
 def public(name: Optional[str] = None) -> Callable[[Callable[..., T]], Callable[..., T]]:
     ...
 
-def public(name):
+def public(name = None):
     # noinspection SpellCheckingInspection
     """Decorator. Mark a method as eligible for registration by a dispatcher.
 
@@ -86,7 +86,7 @@ class RPCDispatcher(object):
     def public(self, name: Optional[str] = None) -> Callable[[Callable[..., T]], Callable[..., T]]:
         ...
 
-    def public(self, name):
+    def public(self, name = None):
         """Convenient decorator.
 
         Allows easy registering of functions to this dispatcher. Example:

--- a/tinyrpc/dispatch/__init__.py
+++ b/tinyrpc/dispatch/__init__.py
@@ -10,13 +10,24 @@ to the caller.
 """
 
 import inspect
-from typing import Callable, Any, Dict, List, Union
+from typing import Callable, Any, Dict, List, Optional, TypeVar, Union, overload
 
 from tinyrpc import RPCRequest, RPCResponse, RPCBatchRequest, RPCBatchResponse
 from .. import exc
 
 
-def public(name: str = None) -> Callable:
+T = TypeVar("T")
+
+
+@overload
+def public(name: Callable[..., T]) -> Callable[..., T]:
+    ...
+
+@overload
+def public(name: Optional[str] = None) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    ...
+
+def public(name):
     # noinspection SpellCheckingInspection
     """Decorator. Mark a method as eligible for registration by a dispatcher.
 
@@ -67,7 +78,15 @@ class RPCDispatcher(object):
         self.method_map = {}
         self.subdispatchers = {}
 
-    def public(self, name: str = None) -> Callable:
+    @overload
+    def public(self, name: Callable[..., T]) -> Callable[..., T]:
+        ...
+
+    @overload
+    def public(self, name: Optional[str] = None) -> Callable[[Callable[..., T]], Callable[..., T]]:
+        ...
+
+    def public(self, name):
         """Convenient decorator.
 
         Allows easy registering of functions to this dispatcher. Example:


### PR DESCRIPTION
This PR improves the typing of the `@public` decorator by making it clear that the decorator may be invoked either with a callable (in which case it returns the decorated callable, whose return value has the same type as the input callable), or with a name, in which case it behaves as a decorator _factory_ and returns a return-type-preserving decorator. This prevents Pyright and other type checkers from printing an error when `@public` is used on a function without arguments.