### PR TITLE
fix: fix undesired sharing of ID generators between protocol instances

### DIFF
--- a/tinyrpc/protocols/jsonrpc.py
+++ b/tinyrpc/protocols/jsonrpc.py
@@ -509,12 +509,12 @@ class JSONRPCProtocol(RPCBatchProtocol):
 
     def __init__(
             self,
-            id_generator: Generator[object, None, None] = default_id_generator(),
+            id_generator: Optional[Generator[object, None, None]] = None,
             *args,
             **kwargs
     ) -> None:
         super(JSONRPCProtocol, self).__init__(*args, **kwargs)
-        self._id_generator = id_generator
+        self._id_generator = id_generator or default_id_generator()
         self._pending_replies = []
 
     def _get_unique_id(self) -> object:

--- a/tinyrpc/protocols/msgpackrpc.py
+++ b/tinyrpc/protocols/msgpackrpc.py
@@ -239,12 +239,12 @@ class MSGPACKRPCProtocol(RPCProtocol):
 
     def __init__(
             self,
-            id_generator: Generator[object, None, None] = default_id_generator(),
+            id_generator: Optional[Generator[object, None, None]] = None,
             *args,
             **kwargs
     ) -> None:
         super(MSGPACKRPCProtocol, self).__init__(*args, **kwargs)
-        self._id_generator = id_generator
+        self._id_generator = id_generator or default_id_generator()
 
     def _get_unique_id(self):
         return next(self._id_generator)


### PR DESCRIPTION
This commit prevents ID generators from being shared between different
RPC protocol instances if an ID generator was not specified explicitly
when constructing them, restoring the ID generation behaviour seen
before 1.1.1 when protocols had independent counters.