### PR TITLE
Include tests in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
                 'library that, among other things, supports JSON-RPC and zmq.',
     long_description=read('README.rst'),
     long_description_content_type="text/x-rst",
-    packages=find_packages(exclude=['tests', 'examples']),
+    packages=find_packages(exclude=['examples']),
     keywords='json rpc json-rpc jsonrpc 0mq zmq zeromq',
     author='Marc Brinkmann',
     author_email='git@marcbrinkmann.de',


### PR DESCRIPTION
It's needed for distro packaging in order to
run the test suite during the build. With that,
we can ensure the software is running properly
on the distribution.