### PR TITLE
Add Python 3.10 and 3.11 to the build matrix

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gevent==23.7.0
+gevent==22.10.2
 gevent-websocket==0.10.1
 msgpack==1.0.2
 pika==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ msgpack==1.0.2
 pika==1.2.0
 pytest==6.2.4
 pytest-cov==2.11.1
-pyzmq==22.0.3
+pyzmq==23.2.1
 requests==2.25.1
 six==1.16.0
 Werkzeug==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gevent==21.1.2
+gevent==23.7.0
 gevent-websocket==0.10.1
 msgpack==1.0.2
 pika==1.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 #envlist = py38
-envlist = py34, py35, py36, py37, py38, py39
+envlist = py34, py35, py36, py37, py38, py39, py310, py311
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
This PR adds Python 3.10 and 3.11 to the list of versions tested in CI.