### PR TITLE
Add pyproject.toml for sake of PEP517 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+


### PR DESCRIPTION
This PR adds a `pyproject.toml` file to the root of the repository for sake of compatiblity with PEP517. No other changes are made to the build process; the package still builds fine with `setup.py`, but now it is possible to run `pipx run build` to build the package using a PEP517-compliant build frontend.