### PR TITLE
Remove dependency on `six`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ pytest==6.2.4
 pytest-cov==2.11.1
 pyzmq==22.0.3
 requests==2.25.1
-six==1.16.0
 Werkzeug==2.0.0
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     maintainer_email='leo@noordergraaf.net',
     url='http://github.com/mbr/tinyrpc',
     license='MIT',
-    install_requires=['six'],
     extras_require={
         'gevent': ['gevent'],
         'httpclient': ['requests', 'websocket-client', 'gevent-websocket'],

--- a/tests/_compat.py
+++ b/tests/_compat.py
@@ -1,8 +1,0 @@
-# from http://stackoverflow.com/questions/28215214/how-to-add-custom-renames-in-six
-
-import six
-mod = six.MovedModule('mock', 'mock', 'unittest.mock')
-six.add_move(mod)
-six._importer._add_module(mod, "moves." + mod.name)
-
-# issue open at https://bitbucket.org/gutworth/six/issue/116/enable-importing-from-within-custom

--- a/tests/test_jsonrpc.py
+++ b/tests/test_jsonrpc.py
@@ -3,7 +3,6 @@
 
 import json
 
-import six
 import pytest
 
 from tinyrpc import MethodNotFoundError, InvalidRequestError, ServerError, \
@@ -65,7 +64,7 @@ def prot():
 def test_parsing_good_request_samples(prot, data, attrs):
     req = prot.parse_request(data)
 
-    for k, v in six.iteritems(attrs):
+    for k, v in attrs.items():
         assert getattr(req, k) == v
 
 

--- a/tests/test_msgpackrpc.py
+++ b/tests/test_msgpackrpc.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import msgpack
-import six
 import pytest
 
 from tinyrpc import InvalidReplyError, MethodNotFoundError
@@ -48,7 +47,7 @@ def prot():
 def test_parsing_good_request_samples(prot, data, attrs):
     req = prot.parse_request(data)
 
-    for k, v in six.iteritems(attrs):
+    for k, v in attrs.items():
         assert getattr(req, k) == v
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-import six
 
 import zmq
 import zmq.green
@@ -20,7 +19,7 @@ class DummyServerTransport(ServerTransport):
         return self.messages.pop()
 
     def send_reply(self, context, message):
-        if not isinstance(message, sid.string_types):
+        if not isinstance(message, str):
             raise TypeError('Message must be str().')
         self.clients[context].messages.append(message)
 
@@ -60,11 +59,9 @@ def zmq_green_context(request):
     return ctx
 
 
-if six.PY3:
-    # zmq and zmq.green fail on python3
-    SERVERS=['dummy']
-else:
-    SERVERS=['dummy', 'zmq', 'zmq.green']
+# zmq and zmq.green fail on python3
+SERVERS=['dummy']
+
 @pytest.fixture(params=SERVERS)
 def transport(request, zmq_context, zmq_green_context):
     if request.param == 'dummy':
@@ -86,11 +83,8 @@ def transport(request, zmq_context, zmq_green_context):
     return (client, server)
 
 SAMPLE_MESSAGES = ['asdf', 'loremipsum' * 1500, '', '\x00', 'b\x00a', '\r\n',
-                   '\n', u'\u1234'.encode('utf8')]
-if six.PY3:
-    BAD_MESSAGES = [b'asdf', b'', 1234, 1.2, None, True, False, ('foo',)]
-else:
-    BAD_MESSAGES = [u'asdf', u'', 1234, 1.2, None, True, False, ('foo',)]
+                   '\n', '\u1234'.encode('utf8')]
+BAD_MESSAGES = [b'asdf', b'', 1234, 1.2, None, True, False, ('foo',)]
 
 
 @pytest.fixture(scope='session',

--- a/tinyrpc/protocols/msgpackrpc.py
+++ b/tinyrpc/protocols/msgpackrpc.py
@@ -14,7 +14,6 @@ from .. import (
 )
 
 import msgpack
-import six
 
 from typing import Any, Dict, List, Optional, Tuple, Union, Generator
 
@@ -104,7 +103,7 @@ class MSGPACKRPCErrorResponse(RPCErrorResponse):
 
 
 def _get_code_and_message(error):
-    assert isinstance(error, (Exception, six.string_types))
+    assert isinstance(error, (Exception, str))
     if isinstance(error, Exception):
         if hasattr(error, "msgpackrpc_error_code"):
             code = error.msgpackrpc_error_code
@@ -390,7 +389,7 @@ class MSGPACKRPCProtocol(RPCProtocol):
             raise MSGPACKRPCInvalidRequestError()
 
     def _parse_notification(self, req):
-        if not isinstance(req[1], six.string_types):
+        if not isinstance(req[1], str):
             raise MSGPACKRPCInvalidRequestError()
 
         request = MSGPACKRPCRequest()
@@ -408,7 +407,7 @@ class MSGPACKRPCProtocol(RPCProtocol):
         return request
 
     def _parse_request(self, req):
-        if not isinstance(req[2], six.string_types):
+        if not isinstance(req[2], str):
             raise MSGPACKRPCInvalidRequestError(request_id=req[1])
 
         request = MSGPACKRPCRequest()


### PR DESCRIPTION
This PR rewrites the unit tests and the code of the core library such that it does not depend on the `six` library any more. This is easy to do now as the package does not need to support Python 2.x any more.

Will solve #103 when merged.